### PR TITLE
Feature/about props

### DIFF
--- a/portfolio-builder-frontend/src/templates/Template1.jsx
+++ b/portfolio-builder-frontend/src/templates/Template1.jsx
@@ -130,6 +130,22 @@ const Template1 = ({
           textClass={section_options.textClass || "text-lg leading-relaxed"}
         />
       );
+      case "grid":
+        return (
+        <AboutGrid
+          data={portfolio}
+          style={glassStyle}
+          containerClass={section_options.containerClass || "container mx-auto py-16"}
+          titleClass={section_options.titleClass || "text-3xl font-bold mb-12 text-center"}
+          gridClass={section_options.gridClass || "grid grid-cols-1 md:grid-cols-2 gap-8"}
+          cardClass={section_options.cardClass || "py-24 px-8 max-w-3xl mx-auto"}
+          bodyClass={section_options.bodyClass || "card-body"}
+          sectionTitleClass={section_options.sectionTitleClass || "card-title"}
+          textClass={section_options.textClass || "leading-relaxed"}
+          skillsContainerClass={section_options.skillsContainerClass || "flex flex-wrap gap-2"}
+          badgeClass={section_options.badgeClass || "badge badge-primary"}
+        />
+      );
     }
   };
 

--- a/portfolio-builder-frontend/src/templates/Template1.jsx
+++ b/portfolio-builder-frontend/src/templates/Template1.jsx
@@ -115,11 +115,21 @@ const Template1 = ({
   const renderAbout = () => {
     switch (about) {
       case "card":
-        return <AboutCard data={portfolio} style={glassStyle} />;
-      case "split":
-        return <AboutSplit data={portfolio} style={glassStyle} />;
-      default:
-        return <AboutGrid data={portfolio} style={glassStyle} />;
+         return (
+        <AboutCard
+          data={portfolio}
+          style={glassStyle}
+          shapeClass={section_options.shape || "rounded-xl"}
+          shadowClass={section_options.shadow || "shadow-xl"}
+          layoutClass={section_options.layoutPos || "text-center"}
+          bgClass={section_options.bgClass || `bg-[${themeStyle.primary}]`}
+          fontClass={fontClasses[font]}
+          cardClass={section_options.cardClass || "py-24 px-8 max-w-3xl mx-auto"}
+          bodyClass={section_options.bodyClass || ""}
+          titleClass={section_options.titleClass || "card-title text-3xl"}
+          textClass={section_options.textClass || "text-lg leading-relaxed"}
+        />
+      );
     }
   };
 

--- a/portfolio-builder-frontend/src/templates/Template1.jsx
+++ b/portfolio-builder-frontend/src/templates/Template1.jsx
@@ -146,6 +146,25 @@ const Template1 = ({
           badgeClass={section_options.badgeClass || "badge badge-primary"}
         />
       );
+      case "split":
+      return (
+        <AboutSplit
+          data={portfolio}
+          style={glassStyle}
+          containerClass={section_options.containerClass || "container mx-auto py-16"}
+          gridClass={section_options.gridClass || "grid grid-cols-1 lg:grid-cols-2 gap-12 items-center"}
+          leftTitleClass={section_options.leftTitleClass || "text-3xl font-bold mb-6"}
+          leftTextClass={section_options.leftTextClass || "text-lg leading-relaxed"}
+          cardClass={section_options.cardClass || "card bg-base-100 shadow-xl"}
+          bodyClass={section_options.bodyClass || "card-body"}
+          sectionTitleClass={section_options.sectionTitleClass || "card-title"}
+          listClass={section_options.listClass || "space-y-2"}
+          listItemClass={section_options.listItemClass || "flex items-center gap-2"}
+          badgeClass={section_options.badgeClass || "badge badge-primary badge-sm"}
+        />
+      );
+    default:
+      return null;
     }
   };
 

--- a/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutCard.jsx
+++ b/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutCard.jsx
@@ -1,12 +1,24 @@
 import React from "react";
 
-const AboutCard = ({ data, style }) => {
+const AboutCard = ({
+  data,
+  style,
+  cardClass = "",
+  shapeClass = "rounded-xl",
+  shadowClass = "shadow-xl",
+  layoutClass = "text-center",
+  bgClass = "bg-base-100",
+  fontClass = "",
+  bodyClass = "",
+  titleClass = "card-title text-3xl",
+  textClass = "text-lg leading-relaxed",
+}) => {
   return (
-    <div className="container mx-auto py-16">
-      <div className="card bg-base-100 shadow-xl" style={style}>
-        <div className="card-body">
-          <h2 className="card-title text-3xl">About Me</h2>
-          <p className="text-lg leading-relaxed">{data.about_text}</p>
+    <div className={`container mx-auto py-16 ${layoutClass}`}>
+      <div className={`card ${bgClass} ${shapeClass} ${shadowClass} ${cardClass} ${fontClass}`} style={style}>
+        <div className={`card-body ${bodyClass}`}>
+          <h2 className={titleClass}>About Me</h2>
+          <p className={textClass}>{data.about_text}</p>
         </div>
       </div>
     </div>

--- a/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutGrid.jsx
+++ b/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutGrid.jsx
@@ -1,22 +1,34 @@
 import React from "react";
 
-const AboutGrid = ({ data, style }) => {
+const AboutGrid = ({ 
+  data,
+  style,
+  containerClass = "container mx-auto py-16",
+  titleClass = "text-3xl font-bold mb-12 text-center",
+  gridClass = "grid grid-cols-1 md:grid-cols-2 gap-8",
+  cardClass = "card bg-base-100 shadow-xl",
+  bodyClass = "card-body",
+  sectionTitleClass = "card-title",
+  textClass = "leading-relaxed",
+  skillsContainerClass = "flex flex-wrap gap-2",
+  badgeClass = "badge badge-primary", 
+}) => {
   return (
-    <div className="container mx-auto py-16">
-      <h2 className="text-3xl font-bold mb-12 text-center">About Me</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div className="card bg-base-100 shadow-xl" style={style}>
-          <div className="card-body">
-            <h3 className="card-title">Background</h3>
-            <p className="leading-relaxed">{data.about_text}</p>
+    <div className={containerClass}>
+      <h2 className={titleClass}>About Me</h2>
+      <div className={gridClass}>
+        <div className={cardClass} style={style}>
+          <div className={bodyClass}>
+            <h3 className={sectionTitleClass}>Background</h3>
+            <p className={textClass}>{data.about_text}</p>
           </div>
         </div>
-        <div className="card bg-base-100 shadow-xl">
-          <div className="card-body">
-            <h3 className="card-title">Skills</h3>
-            <div className="flex flex-wrap gap-2">
+        <div className={cardClass}>
+          <div className={bodyClass}>
+            <h3 className={sectionTitleClass}>Skills</h3>
+            <div className={skillsContainerClass}>
               {data.skills.map((skill, index) => (
-                <div key={index} className="badge badge-primary">
+                <div key={index} className={badgeClass}>
                   {skill.name}
                 </div>
               ))}

--- a/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutSplit.jsx
+++ b/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutSplit.jsx
@@ -1,20 +1,33 @@
 import React from "react";
 
-const AboutSplit = ({ data, style }) => {
+const AboutSplit = ({ 
+  data, 
+  style,
+  containerClass = "container mx-auto py-16",
+  gridClass = "grid grid-cols-1 lg:grid-cols-2 gap-12 items-center",
+  leftTitleClass = "text-3xl font-bold mb-6",
+  leftTextClass = "text-lg leading-relaxed",
+  cardClass = "card bg-base-100 shadow-xl",
+  bodyClass = "card-body",
+  sectionTitleClass = "card-title",
+  listClass = "space-y-2",
+  listItemClass = "flex items-center gap-2",
+  badgeClass = "badge badge-primary badge-sm", 
+}) => {
   return (
-    <div className="container mx-auto py-16">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+    <div className={containerClass}>
+      <div className={gridClass}>
         <div>
-          <h2 className="text-3xl font-bold mb-6">About Me</h2>
-          <p className="text-lg leading-relaxed">{data.about_text}</p>
+          <h2 className={leftTitleClass}>About Me</h2>
+          <p className={leftTextClass}>{data.about_text}</p>
         </div>
-        <div className="card bg-base-100 shadow-xl" style={style}>
-          <div className="card-body">
-            <h3 className="card-title">Quick Facts</h3>
-            <ul className="space-y-2">
+        <div className={cardClass} style={style}>
+          <div className={bodyClass}>
+            <h3 className={sectionTitleClass}>Quick Facts</h3>
+            <ul className={listClass}>
               {data.skills.slice(0, 5).map((skill, index) => (
-                <li key={index} className="flex items-center gap-2">
-                  <div className="badge badge-primary badge-sm"></div>
+                <li key={index} className={listItemClass}>
+                  <div className={badgeClass}></div>
                   {skill.name}
                 </li>
               ))}


### PR DESCRIPTION
- Updates:
    - Refactored AboutCard, AboutGrid, and AboutSplit components to accept all layout and style classes as props.
    - Updated Template1 to pass customizable props to all About section layouts.
    - Made About section layouts (card, grid, split) fully customizable from parent components or UI controls.
    - Ensured consistent prop naming (e.g., bodyClass) across all About components.
   
- Outcome:
    - All About section layouts (AboutCard, AboutGrid, AboutSplit) are now fully customizable via props.**
    - The parent component (Template1) passes style and layout classes as props, allowing dynamic control over appearance.
    - Developers (and users via UI controls) can change container, card, body, title, text, grid, badge, and other classes without modifying the component code.
    :)