### PR TITLE
Add: text size, shadow and border classes

### DIFF
--- a/portfolio-builder-frontend/src/templates/Template1.jsx
+++ b/portfolio-builder-frontend/src/templates/Template1.jsx
@@ -77,6 +77,37 @@ const themes = {
   },
 };
 
+const textSizeClasses = {
+  "text-1": "text-sm",
+  "text-2": "text-base",
+  "text-3": "text-lg",
+  "text-4": "text-xl",
+  "text-5": "text-2xl",
+  "text-6": "text-3xl",
+  "text-7": "text-4xl",
+  "text-8": "text-5xl",
+};
+
+const shadowClasses = {
+  "shadow-1": "shadow-sm",
+  "shadow-2": "shadow",
+  "shadow-3": "shadow-md",
+  "shadow-4": "shadow-lg",
+  "shadow-5": "shadow-xl",
+  "shadow-6": "shadow-2xl",
+  "shadow-none": "shadow-none",
+};
+
+const borderClasses = {
+  "border-1": "rounded-sm",
+  "border-2": "rounded",
+  "border-3": "rounded-md",
+  "border-4": "rounded-lg",
+  "border-5": "rounded-xl",
+  "border-6": "rounded-2xl",
+  "border-full": "rounded-full",
+};
+
 const fontClasses = {
   "font-1": "font-sans",
   "font-2": "font-poppins",
@@ -96,8 +127,15 @@ const Template1 = ({
     about = "grid",
     layout = "grid",
     cardStyle = "style1",
+    textSize = "text-6",    
+    shadow = "shadow-5",      
+    border = "border-5", 
   } = section_options;
   const themeStyle = themes[theme] || themes["theme-1"];
+  
+  const textSizeClass = textSizeClasses[textSize];
+  const shadowClass = shadowClasses[shadow];
+  const borderClass = borderClasses[border];
 
   const glassStyle = themeStyle.glassStyle;
 
@@ -115,13 +153,37 @@ const Template1 = ({
   const renderAbout = () => {
     switch (about) {
       case "card":
-        return <AboutCard data={portfolio} style={glassStyle} />;
+        return (
+          <AboutCard
+            data={portfolio}
+            style={glassStyle}
+            textSizeClass={textSizeClass}
+            shadowClass={shadowClass}
+            borderClass={borderClass}
+          />
+        );
       case "split":
-        return <AboutSplit data={portfolio} style={glassStyle} />;
+        return (
+          <AboutSplit
+            data={portfolio}
+            style={glassStyle}
+            textSizeClass={textSizeClass}
+            shadowClass={shadowClass}
+            borderClass={borderClass}
+          />
+        );
       default:
-        return <AboutGrid data={portfolio} style={glassStyle} />;
+        return (
+          <AboutGrid
+            data={portfolio}
+            style={glassStyle}
+            textSizeClass={textSizeClass}
+            shadowClass={shadowClass}
+            borderClass={borderClass}
+          />
+        );
     }
-  };
+};
 
   const renderProjects = () => {
 
@@ -130,13 +192,16 @@ const Template1 = ({
         layout={layout}
         cardStyle={cardStyle}
         portfolio={portfolio}
+        textSizeClass={textSizeClass}
+        shadowClass={shadowClass}
+        borderClass={borderClass}
       />
     );
   };
 
   return (
     <div
-      className={`portfolio ${fontClasses[font]} p-6`}
+      className={`portfolio ${fontClasses[font]} ${textSizeClass} ${shadowClass} ${borderClass} p-6`}
       style={{
         background: `url(${themeStyle.bgImage})`,
         color: themeStyle.text2,

--- a/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutCard.jsx
+++ b/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutCard.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-const AboutCard = ({ data, style }) => {
+const AboutCard = ({ data, style, textSizeClass, shadowClass, borderClass }) => {
   return (
     <div className="container mx-auto py-16">
-      <div className="card bg-base-100 shadow-xl" style={style}>
+      <div className={`card bg-base-100 ${shadowClass} ${borderClass}`} style={style}>
         <div className="card-body">
-          <h2 className="card-title text-3xl">About Me</h2>
+          <h2 className={`card-title ${textSizeClass}`}>About Me</h2>
           <p className="text-lg leading-relaxed">{data.about_text}</p>
         </div>
       </div>

--- a/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutGrid.jsx
+++ b/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutGrid.jsx
@@ -1,17 +1,17 @@
 import React from "react";
 
-const AboutGrid = ({ data, style }) => {
+const AboutGrid = ({ data, style, textSizeClass, shadowClass, borderClass }) => {
   return (
     <div className="container mx-auto py-16">
-      <h2 className="text-3xl font-bold mb-12 text-center">About Me</h2>
+      <h2 className={`font-bold mb-12 text-center ${textSizeClass}`}>About Me</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div className="card bg-base-100 shadow-xl" style={style}>
+        <div className={`card bg-base-100 ${shadowClass} ${borderClass}`} style={style}>
           <div className="card-body">
             <h3 className="card-title">Background</h3>
             <p className="leading-relaxed">{data.about_text}</p>
           </div>
         </div>
-        <div className="card bg-base-100 shadow-xl">
+        <div className={`card bg-base-100 ${shadowClass} ${borderClass}`}>
           <div className="card-body">
             <h3 className="card-title">Skills</h3>
             <div className="flex flex-wrap gap-2">

--- a/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutSplit.jsx
+++ b/portfolio-builder-frontend/src/templates/layoutParts/abouts/AboutSplit.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 
-const AboutSplit = ({ data, style }) => {
+const AboutSplit = ({ data, style, textSizeClass, shadowClass, borderClass }) => {
   return (
     <div className="container mx-auto py-16">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
         <div>
-          <h2 className="text-3xl font-bold mb-6">About Me</h2>
+          <h2 className={`font-bold mb-6 ${textSizeClass}`}>About Me</h2>
           <p className="text-lg leading-relaxed">{data.about_text}</p>
         </div>
-        <div className="card bg-base-100 shadow-xl" style={style}>
+        <div className={`card bg-base-100 ${shadowClass} ${borderClass}`} style={style}>
           <div className="card-body">
             <h3 className="card-title">Quick Facts</h3>
             <ul className="space-y-2">


### PR DESCRIPTION
Updates:

- Refactored AboutCard, AboutGrid, and AboutSplit components to accept text size, shadow, and border as props.
- Updated Template1 to map style options from section_options and pass them to all About components.

Outcome: 

- The About sections are now fully customizable for text size, shadow, and border styles using Tailwind CSS classes, making the UI flexible and easier to style from a single configuration.